### PR TITLE
fix dma_buf_export for kernel version 3.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ ifeq ($(shell uname), Darwin)
 else
 	if [ -f /usr/bin/yum ] ; then yum install gmp strace python-argparse python-ply python-gevent; else apt-get install libgmp10 strace python-ply python-gevent; fi
 	if [ -f /usr/lib/x86_64-linux-gnu/libgmp.so ] ; then ln -sf /usr/lib/x86_64-linux-gnu/libgmp.so /usr/lib/x86_64-linux-gnu/libgmp.so.3 ; fi
-	if [ -f /usr/lib64/libgmp.so.10 ] ; then ln -s /usr/lib64/libgmp.so.10 /usr/lib64/libgmp.so.3; fi
+	if [ ! -f /usr/lib64/libgmp.so.3 ] && [ -f /usr/lib64/libgmp.so.10 ] ; then ln -s /usr/lib64/libgmp.so.10 /usr/lib64/libgmp.so.3; fi
 endif
 
 install-python-example-dependences:

--- a/drivers/portalmem/portalmem.c
+++ b/drivers/portalmem/portalmem.c
@@ -422,6 +422,10 @@ int portalmem_dmabuffer_create(PortalAlloc portalAlloc)
 				.exp_name = "portalmem",
 				.owner    = THIS_MODULE
 			};
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3,17,0))
+			struct dma_buf_export_info export_info = {
+				.exp_name = "portalmem"
+                        };
 #endif
                         sg = table->sgl;
                         list_for_each_entry_safe(info, tmp_info, &pages, list) {
@@ -456,18 +460,14 @@ int portalmem_dmabuffer_create(PortalAlloc portalAlloc)
 #endif
                                 sg_dma_address(sg) = sg_phys(sg);
                         }
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,0) || LINUX_VERSION_CODE < KERNEL_VERSION(3,17,0))
 			export_info.ops = &dma_buf_ops;
 			export_info.size = len;
 			export_info.flags = O_RDWR;
 			export_info.priv = buffer;
 			dmabuf = dma_buf_export(&export_info);
-#else
-                        dmabuf = dma_buf_export(buffer, &dma_buf_ops, len, O_RDWR
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
-                                                , NULL
-#endif
-                                );
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
+                        dmabuf = dma_buf_export(buffer, &dma_buf_ops, len, O_RDWR , NULL);
 #endif
                         if (IS_ERR(dmabuf))
                                 pa_buffer_free(buffer);

--- a/drivers/portalmem/portalmem.c
+++ b/drivers/portalmem/portalmem.c
@@ -417,15 +417,10 @@ int portalmem_dmabuffer_create(PortalAlloc portalAlloc)
                 int ret = sg_alloc_table(table, infocount, GFP_KERNEL);
                 if (!ret) {
                         struct dma_buf *dmabuf;
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,0) || LINUX_VERSION_CODE == KERNEL_VERSION(3,10,0))
 			struct dma_buf_export_info export_info = {
 				.exp_name = "portalmem",
-				.owner    = THIS_MODULE
 			};
-#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3,17,0))
-			struct dma_buf_export_info export_info = {
-				.exp_name = "portalmem"
-                        };
 #endif
                         sg = table->sgl;
                         list_for_each_entry_safe(info, tmp_info, &pages, list) {
@@ -460,12 +455,14 @@ int portalmem_dmabuffer_create(PortalAlloc portalAlloc)
 #endif
                                 sg_dma_address(sg) = sg_phys(sg);
                         }
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,0) || LINUX_VERSION_CODE < KERNEL_VERSION(3,17,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,0) || LINUX_VERSION_CODE == KERNEL_VERSION(3,10,0))
 			export_info.ops = &dma_buf_ops;
 			export_info.size = len;
 			export_info.flags = O_RDWR;
 			export_info.priv = buffer;
 			dmabuf = dma_buf_export(&export_info);
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3,11,0) || LINUX_VERSION_CODE < KERNEL_VERSION(3,17,0))
+                        dmabuf = dma_buf_export(buffer, &dma_buf_ops, len, O_RDWR);
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
                         dmabuf = dma_buf_export(buffer, &dma_buf_ops, len, O_RDWR , NULL);
 #endif


### PR DESCRIPTION
1. Checking if `libgmp.so.3` before cloning `libgmp.so.10` in `Makefile`.
2. The current kernel version of `Centos 7` is `3.10.0` in which `dma_buf_export` only takes a single argument.