### PR TITLE
Removed PROJDIR variable from sdcard_spi Makefile

### DIFF
--- a/examples/sdcard_spi/Makefile
+++ b/examples/sdcard_spi/Makefile
@@ -9,7 +9,7 @@ H2S_INTERFACES = SPITest:SPIIndication
 MEM_READ_INTERFACES =
 MEM_WRITE_INTERFACES =
 
-PINOUT_FILE += $(PROJDIR)/pin_translation.json
+PINOUT_FILE += pin_translation.json
 PIN_TYPE = SPIMasterPins
 PIN_TYPE_INCLUDE = SPI
 AUTOTOP = --interface pins:SPITest.spiMasterPins


### PR DESCRIPTION
It looks like PROJDIR is no longer defined by connectal so it causes this example to fail to compile. This change fixes it and .matches the other examples that use PINOUT_FILE.