### PR TITLE
Added unmanaged impl constraint option

### DIFF
--- a/doc/library/source/tools/makefilegen.rst
+++ b/doc/library/source/tools/makefilegen.rst
@@ -147,6 +147,13 @@ Hardware Options
 
    Specifies implementation (place and route) constraint file.
 
+.. option:: --unmanaged-implconstraint=file.xdc
+
+   Specifies unmanaged implementation (place and route) constraint file.
+   This causes the xdc file to be read in using the `-unmanaged` flag of `read_xdc`.
+   This allows the xdc files to use more tcl commands than a normal xdc file (including `if` and
+   `foreach`).
+
 .. option:: -P modulename, --partition=modulename
 
    Directs `fpgamake` to build a separate netlist for

--- a/scripts/makefilegen.py
+++ b/scripts/makefilegen.py
@@ -61,6 +61,7 @@ argparser.add_argument(      '--qsf', help='Altera Quartus settings', action='ap
 argparser.add_argument(      '--chipscope', help='Onchip scope settings', action='append', default=[])
 argparser.add_argument('-C', '--constraint', help='Additional constraint files', action='append', default=[])
 argparser.add_argument(      '--implconstraint', help='Physical constraint files', action='append', default=[])
+argparser.add_argument(      '--unmanaged-implconstraint', help='Unmanaged physical constraint files', action='append', default=[])
 argparser.add_argument('-M', '--make', help='Run make on the specified targets', action='append', default=[])
 argparser.add_argument('-D', '--bsvdefine', help='BSV define', action='append', default=[])
 argparser.add_argument('-D2', '--bsvdefine2', help='BSV define2', action='append', default=[])
@@ -349,6 +350,10 @@ if __name__=='__main__':
     if cstr:
         ## preserve the order of items
         options.implconstraint = [os.path.join(connectaldir, item) for item in cstr] + options.implconstraint
+    cstr = option_info.get('unmanaged-implconstraints')
+    if cstr:
+        ## preserve the order of items
+        options.unmanaged_implconstraint= [os.path.join(connectaldir, item) for item in cstr] + options.unmanaged_implconstraint
 
     bsvdefines += ['BOARD_'+boardname]
 
@@ -476,7 +481,8 @@ if __name__=='__main__':
                                          'genxdc_dep' : genxdc_dep,
 					 'floorplan': os.path.abspath(options.floorplan) if options.floorplan else '',
 					 'xdc': ' '.join(['--constraint=%s' % os.path.abspath(xdc) for xdc in options.constraint]
-                                                         + ['--implconstraint=%s' % os.path.abspath(xdc) for xdc in options.implconstraint]),
+                                                         + ['--implconstraint=%s' % os.path.abspath(xdc) for xdc in options.implconstraint]
+                                                         + ['--unmanaged-implconstraint=%s' % os.path.abspath(xdc) for xdc in options.unmanaged_implconstraint]),
 					 'xci': ' '.join(['--xci=%s' % os.path.abspath(xci) for xci in options.xci]),
 					 'qsf': ' '.join(['--qsf=%s' % os.path.abspath(qsf) for qsf in options.qsf]),
 					 'chipscope': ' '.join(['--chipscope=%s' % os.path.abspath(chipscope) for chipscope in options.chipscope]),


### PR DESCRIPTION
This adds support for adding unmanaged implementation constraint files in Vivado with the flag ```--unmanaged-implconstraints```.

An unmanaged constraint file is an XDC file that is imported as a plain TCL file, and vivado will not try to add or remove constraints from the file. This allows for more of the TCL language to be included in the file such as foreach and if. As a side effect of this, some critical warnings in managed constraint files get promotes to errors in unmanaged constraint files, resulting in some builds failing if all constraint files are blindly set to unmanaged.

Unmanaged constraint files are read using the ```-unmanaged``` flag of the ```read_xdc``` command.
