### PR TITLE
Some fixes for synchronizing reset signals across clock domains

### DIFF
--- a/bsv/ConnectalBramFifo.bsv
+++ b/bsv/ConnectalBramFifo.bsv
@@ -60,6 +60,7 @@ module  vmkBramFifo#(String fifo_size, Clock wrClock, Reset wrReset, Clock rdClo
    let rdReset1 <- mkSyncReset(10, rdReset, wrClock);
    let eitherReset <- mkResetEither(wrReset, rdReset1, clocked_by wrClock);
    let positiveReset <- mkPositiveReset(10, eitherReset, wrClock);
+   // rst must be asserted for 5 read and write clock cycles
    let fifoReset = positiveReset.positiveReset;
 `else
    let fifoReset = wrReset;
@@ -78,7 +79,8 @@ module  vmkBramFifo#(String fifo_size, Clock wrClock, Reset wrReset, Clock rdClo
 `endif
    default_clock wrClock(WRCLK) = wrClock;
    no_reset;
-   input_reset wrReset(RST) = fifoReset;
+   // RST is asynchronous
+   input_reset wrReset(RST) clocked_by(no_clock) = fifoReset;
    input_clock rdClock(RDCLK) = rdClock;
    method EMPTY empty() clocked_by (rdClock) reset_by (wrReset);
    method FULL full() clocked_by (wrClock) reset_by (wrReset);

--- a/bsv/ConnectalClocks.bsv
+++ b/bsv/ConnectalClocks.bsv
@@ -113,7 +113,7 @@ import "BVI" PositiveReset =
 module mkPositiveReset#(Integer resetDelay, Reset reset, Clock clock)(PositiveReset);
    parameter RSTDELAY = resetDelay;
    default_clock clock(CLK) = clock;
-   default_reset reset(IN_RST) = reset;
+   default_reset reset(IN_RST) clocked_by (no_clock) = reset;
    output_reset positiveReset(OUT_RST);
 endmodule
 

--- a/verilog/PositiveReset.v
+++ b/verilog/PositiveReset.v
@@ -63,14 +63,20 @@ module PositiveReset (
      begin
         if (IN_RST == `BSV_RESET_VALUE)
            begin
-
               reset_meta <= 1;
-              reset_hold <= `BSV_ASSIGNMENT_DELAY -1 ;
            end
         else
           begin
-	     reset_meta <= next_reset[0];
-             reset_hold <= `BSV_ASSIGNMENT_DELAY next_reset[RSTDELAY:1];
+              reset_meta <= 0;
+          end
+
+        if (reset_meta == 1)
+          begin
+              reset_hold <= `BSV_ASSIGNMENT_DELAY -1 ;
+          end
+        else
+          begin
+              reset_hold <= `BSV_ASSIGNMENT_DELAY next_reset[RSTDELAY:1];
           end
      end // always @ ( posedge CLK )
 

--- a/verilog/SyncReset.v
+++ b/verilog/SyncReset.v
@@ -64,12 +64,18 @@ module SyncReset (
         if (IN_RST == `BSV_RESET_VALUE)
            begin
               reset_meta <= `BSV_ASSIGNMENT_DELAY `BSV_RESET_VALUE ;
-              reset_hold <= `BSV_ASSIGNMENT_DELAY {(RSTDELAY) {`BSV_RESET_VALUE}} ;
            end
         else
+           begin
+              reset_meta <= `BSV_ASSIGNMENT_DELAY ~ `BSV_RESET_VALUE ;
+           end
+        if (reset_meta == `BSV_RESET_VALUE)
           begin
-	     reset_meta <= `BSV_ASSIGNMENT_DELAY next_reset[0];	     
-             reset_hold <= `BSV_ASSIGNMENT_DELAY next_reset[RSTDELAY:1];
+            reset_hold <= `BSV_ASSIGNMENT_DELAY {(RSTDELAY) {`BSV_RESET_VALUE}} ;
+          end
+        else
+          begin
+            reset_hold <= `BSV_ASSIGNMENT_DELAY next_reset[RSTDELAY:1];
           end
      end // always @ ( posedge CLK )
 


### PR DESCRIPTION
This fixes some clock domain crossing issues in PositiveReset.v and SyncReset.v. It also modifies some import BVI statements for reset inputs that don't need to be synchronized to a clock.

This was tested with the ```ddr_minimal``` test on vc707 with ```--mainclockperiod=32``` added to ```CONNECTALFLAGS```. Without this fix, I got the following timing constraints:

```
*** timing violation ***
Slack (VIOLATED) :        -2.109ns  (required time - arrival time)
  Source:                 tile_0_lDdr3Test_ddr3Controller/mc/u_axiddr3_mig/u_memc_ui_top_axi/u_ui_top/ui_wr_data0/app_wdf_rdy_r_copy2_reg/C
                            (rising edge-triggered cell FDRE clocked by clk_pll_i  {rise@0.000ns fall@2.500ns period=5.000ns})
  Destination:            tile_0_lDdr3Test_ddr3Controller/mc/u_axiddr3_mig/u_memc_ui_top_axi/u_ui_top/ui_wr_data0/write_buffer.wr_buffer_ram[73].RAM32M0/RAMC_D1/I
                            (rising edge-triggered cell RAMD32 clocked by clk_pll_i  {rise@0.000ns fall@2.500ns period=5.000ns})

*** timing violation ***
Slack (VIOLATED) :        -0.306ns  (required time - arrival time)
  Source:                 host_pcieHostTop_pciehost_csr/csrOneHotFifo774/data0_reg_reg[2]/C
                            (rising edge-triggered cell FDRE clocked by userclk2  {rise@0.000ns fall@2.000ns period=4.000ns})
  Destination:            host_pcieHostTop_pciehost_csr/readResponseFifo/data0_reg_reg[27]/D
                            (rising edge-triggered cell FDRE clocked by userclk2  {rise@0.000ns fall@2.000ns period=4.000ns})

*** timing violation ***
Slack (VIOLATED) :        -4.099ns  (required time - arrival time)
  Source:                 host_pcieHostTop_ep7/portalReset/reset_hold_reg[4]/C
                            (rising edge-triggered cell FDRE clocked by clkgen_pll_CLKOUT1  {rise@0.000ns fall@16.000ns period=32.000ns})
  Destination:            tile_0_lDdr3Test_ddr3Controller/rst200/reset_hold_reg[3]/R
                            (rising edge-triggered cell FDRE clocked by sys_clk  {rise@0.000ns fall@2.500ns period=5.000ns})

*** timing violation ***
Slack (VIOLATED) :        -2.769ns  (required time - arrival time)
  Source:                 host_pcieHostTop_ep7/portalReset/reset_hold_reg[4]/C
                            (rising edge-triggered cell FDRE clocked by clkgen_pll_CLKOUT1  {rise@0.000ns fall@16.000ns period=32.000ns})
  Destination:            tile_0_lDdr3Test_bfifo_fifos_0_rdReset1/reset_hold_reg[4]/R
                            (rising edge-triggered cell FDRE clocked by clk_pll_i  {rise@0.000ns fall@2.500ns period=5.000ns})

*** timing violation ***
Slack (VIOLATED) :        -1.747ns  (required time - arrival time)
  Source:                 tile_0_lDdr3Test_ddr3Controller/mc/u_axiddr3_mig/u_ddr3_infrastructure/rstdiv0_sync_r1_reg_rep/C
                            (rising edge-triggered cell FDPE clocked by clk_pll_i  {rise@0.000ns fall@2.500ns period=5.000ns})
  Destination:            tile_0_lDdr3Test_arfifo_fifos_0_rdReset1/reset_hold_reg[1]/R
                            (rising edge-triggered cell FDRE clocked by clkgen_pll_CLKOUT1  {rise@0.000ns fall@16.000ns period=32.000ns})

*** timing violation ***
Slack (VIOLATED) :        -3.260ns  (required time - arrival time)
  Source:                 tile_0_lDdr3Test_dramWriteFifo_fifos_4_positiveReset/reset_hold_reg[10]/C
                            (rising edge-triggered cell FDSE clocked by clkgen_pll_CLKOUT1  {rise@0.000ns fall@16.000ns period=32.000ns})
  Destination:            tile_0_lDdr3Test_dramWriteFifo_fifos_4/genblk5_0.fifo_18_bl_1.fifo_18_bl_1/RST
                            (recovery check against rising-edge clock clk_pll_i  {rise@0.000ns fall@2.500ns period=5.000ns})

*** timing violation ***
Slack (VIOLATED) :        -1.619ns  (required time - arrival time)
  Source:                 tile_0_lDdr3Test_ddr3Controller/rst200/reset_hold_reg[9]/C
                            (rising edge-triggered cell FDRE clocked by sys_clk  {rise@0.000ns fall@2.500ns period=5.000ns})
  Destination:            tile_0_lDdr3Test_ddr3Controller/mc/u_axiddr3_mig/u_ddr3_infrastructure/rstdiv0_sync_r1_reg_rep__2/PRE
                            (recovery check against rising-edge clock clk_pll_i  {rise@0.000ns fall@2.500ns period=5.000ns})

*** timing violation ***
Slack (VIOLATED) :        -2.662ns  (required time - arrival time)
  Source:                 tile_0_lDdr3Test_dramReadFifo_fifos_9_positiveReset/reset_hold_reg[10]/C
                            (rising edge-triggered cell FDSE clocked by clk_pll_i  {rise@0.000ns fall@2.500ns period=5.000ns})
  Destination:            tile_0_lDdr3Test_dramReadFifo_fifos_9/genblk5_0.fifo_18_bl_1.fifo_18_bl_1/RST
                            (recovery check against rising-edge clock clkgen_pll_CLKOUT1  {rise@0.000ns fall@16.000ns period=32.000ns})

*** timing violation ***
Slack (VIOLATED) :        -2.285ns  (required time - arrival time)
  Source:                 tile_0_lDdr3Test_ddr3Controller/rst200/reset_hold_reg[9]/C
                            (rising edge-triggered cell FDRE clocked by sys_clk  {rise@0.000ns fall@2.500ns period=5.000ns})
  Destination:            tile_0_lDdr3Test_ddr3Controller/mc/u_axiddr3_mig/u_ddr3_infrastructure/rst_sync_r1_reg/PRE
                            (recovery check against rising-edge clock mmcm_ps_clk_bufg_in  {rise@0.000ns fall@5.000ns period=10.000ns})
```

Applying this commit removed all the timing violations for paths to reset_hold_reg*, but it did not remove the timing violations for the paths leading to reset_meta_reg.

To remove the rest of the timing errors from (hopefully?) false paths, I used the following unmanaged implementation constraint file:
```
foreach fifo_rst_pin [get_pins -filter {NAME =~ *RST} -of_objects [get_cells -hier -filter {FILE_NAME =~ */FIFO_DUALCLOCK_MACRO.v} *]] {
    set driving_clk [all_fanin -flat -startpoints_only $fifo_rst_pin]
    puts "set_false_path -reset_path -from $driving_clk -to $fifo_rst_pin"
    set_false_path -reset_path -from $driving_clk -to $fifo_rst_pin
}
foreach reset_meta_reg [get_cells -hier -filter {FILE_NAME =~ */PositiveReset.v || FILE_NAME =~ */SyncReset.v} reset_meta_reg] {
    set reset_meta_pins [get_pins -filter {NAME =~ */D || NAME =~ */S} -of_objects $reset_meta_reg]
    set driving_clk [all_fanin -flat -startpoints_only $reset_meta_pins]

    foreach s $driving_clk {
        foreach d $reset_meta_pins {
            puts "set_false_path -reset_path -from $s -to $d"
            set_false_path -reset_path -from $s -to $d
        }
    }
}
```
Removing the false paths removed all timing constraints in the rest of the design.