### PR TITLE
More #!/usr/bin/env python

### DIFF
--- a/examples/echopy/testecho.py
+++ b/examples/echopy/testecho.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014 Quanta Research Cambridge, Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/generated/scripts/importbvi.py
+++ b/generated/scripts/importbvi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2013 Quanta Research Cambridge, Inc.
 #
 # Permission is hereby granted, free of charge, to any person

--- a/jtag/dumptrace.py
+++ b/jtag/dumptrace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2013 Quanta Research Cambridge, Inc.
 #
 # Permission is hereby granted, free of charge, to any person

--- a/jtag/readll.py
+++ b/jtag/readll.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2013 Quanta Research Cambridge, Inc.
 #
 # Permission is hereby granted, free of charge, to any person

--- a/pcie/pcieflat
+++ b/pcie/pcieflat
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014 Quanta Research Cambridge, Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/pcie/tlp.py
+++ b/pcie/tlp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import re

--- a/scripts/boardinfo.py
+++ b/scripts/boardinfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014 Quanta Research Cambridge, Inc.
 #
 # Permission is hereby granted, free of charge, to any person

--- a/scripts/bsv.filter
+++ b/scripts/bsv.filter
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Usage doxyfilter_bsv.psv < infile.bsv > outfile.java
 
 import fileinput

--- a/scripts/bsvdepend.py
+++ b/scripts/bsvdepend.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2015 Connectal Project
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/scripts/bsvdependencies.py
+++ b/scripts/bsvdependencies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2015 Connectal Project
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/scripts/bsvpreprocess.py
+++ b/scripts/bsvpreprocess.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014-2015 Quanta Research Cambridge, Inc
 # Copyright (c) 2015 Connectal Project
 #

--- a/scripts/check-timing.py
+++ b/scripts/check-timing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys, re
 

--- a/scripts/extract-bvi-schedule.py
+++ b/scripts/extract-bvi-schedule.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2015 Connectal Project
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/scripts/generate-constraints.py
+++ b/scripts/generate-constraints.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2013 Quanta Research Cambridge, Inc.
 #
 # Permission is hereby granted, free of charge, to any person

--- a/scripts/globalv.py
+++ b/scripts/globalv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 globaldecls = []
 globalvars = {}

--- a/scripts/makefilegen.py
+++ b/scripts/makefilegen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 ## Copyright (c) 2013-2014 Quanta Research Cambridge, Inc.
 
 ## Permission is hereby granted, free of charge, to any person

--- a/scripts/packagesource.py
+++ b/scripts/packagesource.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os, sys
 import glob

--- a/scripts/parse_qsf.py
+++ b/scripts/parse_qsf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import print_function
 import sys

--- a/scripts/parse_xdc.py
+++ b/scripts/parse_xdc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # parse xdc pin assignment to json
 

--- a/scripts/portal.py
+++ b/scripts/portal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2016 Connectal Project
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/scripts/reorderbytes.py
+++ b/scripts/reorderbytes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014 Quanta Research Cambridge, Inc.
 #
 # Permission is hereby granted, free of charge, to any person

--- a/scripts/syntax.py
+++ b/scripts/syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014 Quanta Research Cambridge, Inc
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/tests/bluecheck_harness/harness.py
+++ b/tests/bluecheck_harness/harness.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2016 Connectal Project
 #
 # Permission is hereby granted, free of charge, to any person obtaining a


### PR DESCRIPTION
Hi,

I'm trying to play around with this on NixOS, and one of the things it doesn't have is `python` in `/usr/bin`, so I have patched up all I could find to `/usr/bin/env python`.

There are some more things which might break:
```
$ grep -r '/usr/bin/'|grep '/usr/bin/env' -v
Makefile:       if [ -f /usr/bin/yum ] ; then yum install gmp strace python-argparse python-ply python-gevent; else apt-get install libgmp10 strace python-ply python-gevent; fi
cpp/runpython.cpp:    statok = stat("/usr/bin/python", &statbuf);
debian/connectal.install:/usr/bin/pcieflat
debian/rules:#!/usr/bin/make -f
examples/gyro_simple/test_gyro.py:            octave_file.write("#! /usr/bin/octave --persist \nv = [");
scripts/Doxyfile:PERL_PATH              = /usr/bin/perl
tests/spikehw/README.md:    Running /usr/bin/pciescan.sh
```
Of these, the three I think would break are the `runpython.cpp`,
`Doxyfile` and the `test_gyro.py`.
- The runpython.cpp possibly needs to be patched up to search along
  $PATH, which is a more substantial change so I have left it as is for
  now.
- The Doxyfile says it requires an absolute path.
- I can't just do `#! /usr/bin/env octave ...` because env doesn't do
  arguments, so I have left it as is.

P.S.: Here is the `shell.nix` file I'm using
```nix
{ nixpkgs ? import <nixpkgs> {}
}:

with nixpkgs;
stdenv.mkDerivation {
  name = "connectal";
  version = "1.0.0";
  buildInputs = [
    bluespec
    strace
    gmp
    (python.withPackages (p: with p; [ ply gevent ]))
  ];
}
```