### PR TITLE
Allow AWS F1 projects to configure their own clocks

### DIFF
--- a/boardinfo/awsf1.json
+++ b/boardinfo/awsf1.json
@@ -10,7 +10,7 @@
         "constraints": ["constraints/xilinx/awsf1.xdc"],
         "implconstraints": ["constraints/xilinx/awsf1.xdc"],
         "runscript" : "run.pcietest",
-        "CONNECTALFLAGS" : ["--mainclockperiod=8", "--derivedclockperiod=4", "--pcieclockperiod=8"],
+        "CONNECTALFLAGS" : ["--mainclockperiod=8", "--derivedclockperiod=8", "--pcieclockperiod=8"],
         "rewireclockstring" : ""
     },
     "pins": {

--- a/bsv/AwsF1Top.bsv
+++ b/bsv/AwsF1Top.bsv
@@ -47,6 +47,7 @@ import AxiBits::*;
 import AxiDma::*;
 import FIFOF::*;
 import ConnectalFIFO::*;
+import Clocks::*;
 
 `include "ConnectalProjectConfig.bsv"
 
@@ -261,10 +262,15 @@ module mkAwsF1Top#(Clock clk_main_a0, Clock clk_extra_a1, Clock clk_extra_a2, Cl
 
    Clock defaultClock = clk_main_a0;
    Reset defaultReset = rst_main_n;
+`ifdef AWSF1_DERIVED_CLOCK
+   Clock derivedClock = `AWSF1_DERIVED_CLOCK;
+   Reset derivedReset <- mkAsyncReset(5, rst_main_n, derivedClock);
+`else
    Clock derivedClock = clk_main_a0;
    Reset derivedReset = rst_main_n;
+`endif
 
-   XsimHost host <- mkXsimHost(clk_main_a0, rst_main_n, clk_main_a0);
+   XsimHost host <- mkXsimHost(derivedClock, derivedReset, defaultClock);
    let top <- mkConnectalTop(
 `ifdef IMPORT_HOSTIF
        host,

--- a/scripts/Makefile.connectal.build
+++ b/scripts/Makefile.connectal.build
@@ -394,7 +394,7 @@ bsim: prepare_bin_target $(DTOP)/bin/libconnectal-sim.so obj/mkXsimTop.ba
 
 
 build/checkpoints/to_aws/mkTop.SH_CL_routed.dcp: verilog
-	CONNECTALDIR=$(CONNECTALDIR) $(CONNECTALDIR)/scripts/aws/build.sh
+	CONNECTALDIR=$(CONNECTALDIR) $(CONNECTALDIR)/scripts/aws/build.sh $(AWSFLAGS)
 
 syntax.timestamp: $(BSVFILES)
 	@#$syntax.py uses environment variables: V INTERFACES BSVDEFINES_LIST DTOP DUT_NAME

--- a/scripts/aws/build.sh
+++ b/scripts/aws/build.sh
@@ -71,7 +71,7 @@ echo '#placeholder' > ../constraints/cl_pnr_user.xdc
 echo '#placeholder' > ../constraints/cl_synth_user.xdc
 
 ## run Vivado to build the FPGA image
-$AWS_FPGA_REPO_DIR/hdk/common/shell_stable/build/scripts/aws_build_dcp_from_cl.sh -ignore_memory_requirement -strategy CONGESTION -clock_recipe_a A0 -notify -foreground
+$AWS_FPGA_REPO_DIR/hdk/common/shell_stable/build/scripts/aws_build_dcp_from_cl.sh -ignore_memory_requirement -notify -foreground "$@"
 
 PROJECT_DIR=`dirname $CL_DIR`
 PROJECT_NAME=`basename $PROJECT_DIR`

--- a/scripts/aws/encrypt.tcl
+++ b/scripts/aws/encrypt.tcl
@@ -38,7 +38,7 @@ foreach {file} [glob -nocomplain -- $CL_DIR/verilog/*.v $CL_DIR/verilog/*.sv $CL
 }
 foreach {dir} "$BLUESPECDIR/Verilog $BLUESPECDIR/Verilog.Vivado $CONNECTALDIR/verilog $HDK_SHELL_DIR/design/interfaces" {
     puts "Looking in directory $dir"
-    foreach {pat} {FIFO BRAM Reg Counter Reset cl_ unused aws} {
+    foreach {pat} {FIFO BRAM Reg Counter Reset Sync cl_ unused aws} {
 	foreach {file} [glob -nocomplain -- $dir/*$pat*.v $dir/*$pat*.vh $dir/*$pat*.inc $dir/*$pat*.sv] {
 	    puts "Copying file $file"
 	    file copy -force $file            $TARGET_DIR

--- a/scripts/makefilegen.py
+++ b/scripts/makefilegen.py
@@ -74,6 +74,7 @@ argparser.add_argument('-m', '--bsimsource', help='Bsim C++ source files', actio
 argparser.add_argument('-b', '--bscflags', help='Options to pass to the BSV compiler', action='append', default=[])
 argparser.add_argument('--xelabflags', help='Options to pass to the xelab compiler', action='append', default=[])
 argparser.add_argument('--xsimflags', help='Options to pass to the xsim simulator', action='append', default=[])
+argparser.add_argument('--awsflags', help='Options to pass to aws_build_dcp_from_cl.sh', action='append', default=[])
 argparser.add_argument('--ipdir', help='Directory in which to store generated IP')
 argparser.add_argument('-q', '--qtused', help='Qt used in simulator test application', action='store_true')
 argparser.add_argument('--stl', help='STL implementation to use for Android builds', default=None, choices=supported_stl)
@@ -175,6 +176,7 @@ CFLAGS_PROJECT = %(cflags)s
 CXXFLAGS_PROJECT = %(cxxflags)s
 XELABFLAGS = %(xelabflags)s
 XSIMFLAGS  = %(xsimflags)s
+AWSFLAGS   = %(awsflags)s
 TOPBSVFILE = %(topbsvfile)s
 BSVDEFINES = %(bsvdefines)s
 QTUSED = %(qtused)s
@@ -536,6 +538,7 @@ if __name__=='__main__':
                                    'bscflags': ' '.join(options.bscflags),
                                    'xelabflags': ' '.join(options.xelabflags),
                                    'xsimflags': ' '.join(options.xsimflags),
+                                   'awsflags': ' '.join(options.awsflags),
                                    'cflags': ' ' .join(options.cflags),
                                    'cxxflags': ' ' .join(options.cxxflags),
                                    'bsvdefines_list': ' '.join(bsvdefines),


### PR DESCRIPTION
This gives a Connectal project control over what its derived clock is, as well as the ability to change the main clock recipe. This mechanism is also general enough to mean that we can stop hard-coding a specific strategy and let the project pass whatever `-strategy` flag they want if DEFAULT isn't good enough.