### PR TITLE
Allow projects to provide their own strategy overrides

### DIFF
--- a/scripts/aws/create_dcp_from_cl.tcl
+++ b/scripts/aws/create_dcp_from_cl.tcl
@@ -195,6 +195,10 @@ switch $strategy {
         source $HDK_SHELL_DIR/build/scripts/strategy_DEFAULT.tcl
     }
 }
+if { [file exists $CL_DIR/strategy_OVERRIDES.tcl] } {
+    puts "Custom OVERRIDES for strategy."
+    source $CL_DIR/strategy_OVERRIDES.tcl
+}
 
 #Encrypt source code
 source encrypt.tcl


### PR DESCRIPTION
We can't let them define their own strateiges, as the HDK's
aws_build_dcp_from_cl.sh wrapper validates -strategy, but this provides
equivalent functionality, whilst also allowing projects to easily
inherit defaults from the requested strategy.