### PR TITLE
Fix key when getting typedef

### DIFF
--- a/scripts/cppgen.py
+++ b/scripts/cppgen.py
@@ -384,7 +384,7 @@ def hasBitWidth(item):
 def getNumeric(item):
    if globalv_globalvars.has_key(item['name']):
        decl = globalv_globalvars[item['name']]
-       if decl.get('type') == 'TypeDef':
+       if decl.get('dtype') == 'TypeDef':
            return getNumeric(decl['tdtype'])
    elif item['name'] in ['TAdd', 'TSub', 'TMul', 'TDiv', 'TLog', 'TExp', 'TMax', 'TMin']:
        values = [getNumeric(p) for p in item['params']]


### PR DESCRIPTION
This fixes a typo that prevents the parsing of typedefs like `TAdd#(5, SomeNumericType)` where `SomeNumericType` is another type, not a literal number.