### PR TITLE
AWS: Allow projects to add additional files

### DIFF
--- a/scripts/aws/synth_awsf1.tcl
+++ b/scripts/aws/synth_awsf1.tcl
@@ -58,6 +58,11 @@ if {$AWSF1_CL_DEBUG_BRIDGE} {
 	    ]
 }
 
+if { [file exists $CL_DIR/read_extra_files.tcl] } {
+    puts "Reading extra files"
+    source $CL_DIR/read_extra_files.tcl
+}
+
 #---- End of section replaced by User ----
 
 puts "AWS FPGA: Reading AWS Shell design";


### PR DESCRIPTION
This is useful for projects that want to add additional Xilinx IP, or other files not caught by the existing rudimentary read_verilog glob.
