### PR TITLE
Fix build fatal on RHEL8

### DIFF
--- a/drivers/pcieportal/cdev_ctrl.c
+++ b/drivers/pcieportal/cdev_ctrl.c
@@ -145,13 +145,13 @@ long char_ctrl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	}
 
 	if (_IOC_DIR(cmd) & _IOC_READ) {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)) && !(defined(RHEL_MAJOR) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0))
 		result = !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
 #else
 		result = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
 #endif
 	} else if (_IOC_DIR(cmd) & _IOC_WRITE)
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)) && !(defined(RHEL_MAJOR) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0))
 		result =  !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
 #else
 		result =  !access_ok((void __user *)arg, _IOC_SIZE(cmd));

--- a/drivers/pcieportal/portal.c
+++ b/drivers/pcieportal/portal.c
@@ -201,13 +201,13 @@ static long pcieportal_ioctl(struct file *filp, unsigned int cmd, unsigned long 
             this_board = this_portal->board;
         /* basic sanity checks */
         if (_IOC_DIR(cmd) & _IOC_READ) {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)) && !(defined(RHEL_MAJOR) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0))
                 err = !access_ok(VERIFY_WRITE, (void __user *) arg, _IOC_SIZE(cmd));
 #else
                 err = !access_ok((void __user *) arg, _IOC_SIZE(cmd));
 #endif
         } else if (_IOC_DIR(cmd) & _IOC_WRITE) {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)) && !(defined(RHEL_MAJOR) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0))
                 err = !access_ok(VERIFY_WRITE, (void __user *) arg, _IOC_SIZE(cmd));
 #else
                 err = !access_ok((void __user *) arg, _IOC_SIZE(cmd));

--- a/drivers/pcieportal/xdma_mod.c
+++ b/drivers/pcieportal/xdma_mod.c
@@ -280,7 +280,11 @@ static void xdma_error_resume(struct pci_dev *pdev)
 	struct xdma_pci_dev *xpdev = dev_get_drvdata(&pdev->dev);
 
 	pr_info("dev 0x%p,0x%p.\n", pdev, xpdev);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0) && !(defined(RHEL_MAJOR) && RHEL_RELEASE_VERSION(8,3) >= RHEL_RELEASE_CODE)
 	pci_cleanup_aer_uncorrect_error_status(pdev);
+#else
+	pci_aer_clear_nonfatal_status(pdev);
+#endif
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)

--- a/drivers/portalmem/portalmem.c
+++ b/drivers/portalmem/portalmem.c
@@ -350,12 +350,14 @@ static struct dma_buf_ops dma_buf_ops = {
         .kmap             = pa_dma_buf_kmap,
         .kunmap           = pa_dma_buf_kunmap,
 #else
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)) && !(defined(RHEL_MAJOR) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0))
         .map_atomic       = pa_dma_buf_kmap,
         .unmap_atomic     = pa_dma_buf_kunmap,
 #endif
+#if !(defined(RHEL_MAJOR) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0))
         .map              = pa_dma_buf_kmap,
         .unmap            = pa_dma_buf_kunmap,
+#endif
 #endif
         .vmap             = pa_dma_buf_vmap,
         .vunmap           = pa_dma_buf_vunmap,


### PR DESCRIPTION
The driver build failed on RHEL 8.3, this is workaround fix.