### PR TITLE
Fix `pciedriver` and `portalmem` to support newest kernel versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ kc705g2
 ac701g2
 *.ltx
 zedboard_ubuntu
+driverversion.h
+*.o
+*.d
+*.mod

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ uninstall:
 	    rm -vf $(MODULES_LOAD_D_DIR)/`basename $$fname` ; \
 	done;
 	(cd drivers/pcieportal; make uninstall)
-	make -C pcie/connectalutil uninstall
 	for fname in $(UDEV_RULES) ; do \
 	    rm -f $(UDEV_RULES_DIR)/$$fname ; \
 	done
@@ -117,7 +116,7 @@ ifeq ($(shell uname), Darwin)
 	port install asciidoc
 	easy_install ply
 else
-	if [ -f /usr/bin/yum ] ; then yum install gmp strace python-argparse python-ply python-gevent; else apt-get install libgmp10 strace python-ply python-gevent; fi
+	if [ -f /usr/bin/yum ] ; then yum install gmp strace python-argparse python-ply python3-gevent; else apt-get install libgmp10 strace python-ply python3-gevent; fi
 	if [ -f /usr/lib/x86_64-linux-gnu/libgmp.so ] ; then ln -sf /usr/lib/x86_64-linux-gnu/libgmp.so /usr/lib/x86_64-linux-gnu/libgmp.so.3 ; fi
 	if [ ! -f /usr/lib64/libgmp.so.3 ] && [ -f /usr/lib64/libgmp.so.10 ] ; then ln -s /usr/lib64/libgmp.so.10 /usr/lib64/libgmp.so.3; fi
 endif

--- a/boardinfo/awsf1.json
+++ b/boardinfo/awsf1.json
@@ -3,7 +3,7 @@
         "bsvdefines" : ["XILINX=1", "VirtexUltrascale", "PhysAddrWidth=40", "DataBusWidth=512", "XsimHostInterface", "AWSF1=1",
 			"MemTagSize=16", "MemServerTags=8",
 			"DEFAULT_NOPROGRAM=1",
-		       	"CONNECTAL_BITS_DEPENDENCES=build/checkpoints/to_aws/mkTop.SH_CL_routed.dcp", "CONNECTAL_RUN_SCRIPT=$(CONNECTALDIR)/scripts/run.aws"],
+			"CONNECTAL_BITS_DEPENDENCES=build/checkpoints/to_aws/mkTop.SH_CL_routed.dcp", "CONNECTAL_RUN_SCRIPT=$(CONNECTALDIR)/scripts/aws/run.awsf1"],
         "os" : "ubuntu",
         "partname" : "xcvu9p-flgb2104-2-i",
         "TOP" : "AwsF1Top",

--- a/cpp/poller.cpp
+++ b/cpp/poller.cpp
@@ -187,8 +187,8 @@ void* PortalPoller::event(void)
     if (rc < 0)
         fprintf(stderr, "[%s:%d] read error %d\n", __FUNCTION__, __LINE__, errno);
     for (int i = 0; i < numWrappers; i++) {
-        // if (!portal_wrappers)
-        //     fprintf(stderr, "Poller: No portal_instances revents=%d\n", portal_fds[i].revents);
+        if (!portal_wrappers)
+             fprintf(stderr, "Poller: No portal_instances revents=%d\n", portal_fds[i].revents);
         Portal *instance = portal_wrappers[i];
         if (trace_poller)
             fprintf(stderr, "Poller: event tile %d fpga%d fd %d handler %p parent %p\n",

--- a/cpp/poller.cpp
+++ b/cpp/poller.cpp
@@ -187,8 +187,8 @@ void* PortalPoller::event(void)
     if (rc < 0)
         fprintf(stderr, "[%s:%d] read error %d\n", __FUNCTION__, __LINE__, errno);
     for (int i = 0; i < numWrappers; i++) {
-        if (!portal_wrappers)
-            fprintf(stderr, "Poller: No portal_instances revents=%d\n", portal_fds[i].revents);
+        // if (!portal_wrappers)
+        //     fprintf(stderr, "Poller: No portal_instances revents=%d\n", portal_fds[i].revents);
         Portal *instance = portal_wrappers[i];
         if (trace_poller)
             fprintf(stderr, "Poller: event tile %d fpga%d fd %d handler %p parent %p\n",

--- a/cpp/poller.cpp
+++ b/cpp/poller.cpp
@@ -187,8 +187,6 @@ void* PortalPoller::event(void)
     if (rc < 0)
         fprintf(stderr, "[%s:%d] read error %d\n", __FUNCTION__, __LINE__, errno);
     for (int i = 0; i < numWrappers; i++) {
-        if (!portal_wrappers)
-            fprintf(stderr, "Poller: No portal_instances revents=%d\n", portal_fds[i].revents);
         Portal *instance = portal_wrappers[i];
         if (trace_poller)
             fprintf(stderr, "Poller: event tile %d fpga%d fd %d handler %p parent %p\n",

--- a/cpp/poller.cpp
+++ b/cpp/poller.cpp
@@ -188,7 +188,7 @@ void* PortalPoller::event(void)
         fprintf(stderr, "[%s:%d] read error %d\n", __FUNCTION__, __LINE__, errno);
     for (int i = 0; i < numWrappers; i++) {
         if (!portal_wrappers)
-             fprintf(stderr, "Poller: No portal_instances revents=%d\n", portal_fds[i].revents);
+            fprintf(stderr, "Poller: No portal_instances revents=%d\n", portal_fds[i].revents);
         Portal *instance = portal_wrappers[i];
         if (trace_poller)
             fprintf(stderr, "Poller: event tile %d fpga%d fd %d handler %p parent %p\n",

--- a/drivers/pcieportal/pcieportal.c
+++ b/drivers/pcieportal/pcieportal.c
@@ -40,8 +40,8 @@
 #include <linux/poll.h>         /* poll_table, etc. */
 #include <asm/uaccess.h>        /* copy_to_user, copy_from_user */
 #include <linux/dma-buf.h>
-// #include <linux/dma-mapping.h>
-// #include <linux/dma-direction.h>
+#include <linux/dma-mapping.h>
+#include <linux/dma-direction.h>
 #include <linux/pci_regs.h>
 #include "driverversion.h"
 

--- a/pcie/pcieflat
+++ b/pcie/pcieflat
@@ -23,7 +23,7 @@
 from __future__ import print_function
 
 import fcntl, glob, json, struct, subprocess, sys
-from gmpy import mpz
+from gmpy2 import mpz
 BNOC_TRACE = 0xc008b508
 Trace_len = 144
 struct_traceData = '@ L I I 16I 16I'
@@ -415,7 +415,7 @@ if __name__ == '__main__':
         base = int(tlpfirst[0:16],16)
         base = int(tlpfirst[0:8],16)
     else:
-        fd = open(devfilenames[0], 'rw')
+        fd = open(devfilenames[0], 'w')
         try:
             while 1:
                 buf = fcntl.ioctl(fd, PCIE_CHANGE_ENTRY, ' ' * ChangeEntry_len)
@@ -441,7 +441,7 @@ if __name__ == '__main__':
             buf = fcntl.ioctl(fd, BNOC_GET_TLP, ' ' * Tlp_len)
             foo = ''
             for x in buf:
-                foo = "%02x" % ord( x ) + foo
+                foo = "%02x" % x + foo
             tlplog.append(foo)
         fcntl.ioctl(fd, BNOC_ENABLE_TRACE, 1)
         #for foo in tlplog:

--- a/pcie/pcieflat
+++ b/pcie/pcieflat
@@ -439,10 +439,7 @@ if __name__ == '__main__':
         while counter > 0:
             counter = counter - 1
             buf = fcntl.ioctl(fd, BNOC_GET_TLP, ' ' * Tlp_len)
-            foo = ''
-            for x in buf:
-                foo = "%02x" % x + foo
-            tlplog.append(foo)
+            tlplog.append(buf[::-1].hex())
         fcntl.ioctl(fd, BNOC_ENABLE_TRACE, 1)
         #for foo in tlplog:
         #    print foo

--- a/scripts/Makefile.connectal.build
+++ b/scripts/Makefile.connectal.build
@@ -315,7 +315,7 @@ bin/cvcsim: $(DTOP)/bin/libconnectal-sim.so verilog bin/cvcsim
 
 vlsim:  $(DTOP)/obj_dir/vlsim
 
-VERILATOR_ARGS?= -O3 -CFLAGS "-I$(CONNECTALDIR)/cpp -I$(DTOP)/jni -O $(PROF_FLAGS)" -LDFLAGS "-O $(PROF_FLAGS)" --profile-cfuncs --output-split 20000
+VERILATOR_ARGS?= -O3 -CFLAGS "-I$(CONNECTALDIR)/cpp -I$(DTOP)/jni -O $(PROF_FLAGS)" -LDFLAGS "-O $(PROF_FLAGS)" --profile-cfuncs --output-split 20000 --no-timing
 VERILATOR_ARGS += $(VERILATOR_PROJECT_ARGS)
 
 $(DTOP)/obj_dir/vlsim.mk: $(DTOP)/bin/libconnectal-sim.so verilog

--- a/scripts/aws/notify_via_sns.py
+++ b/scripts/aws/notify_via_sns.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python33
+#!/usr/bin/env python3
 
 # Amazon FPGA Hardware Development Kit
 #


### PR DESCRIPTION
RHEL7 has hit EOL, so do Amazon's old version of FPGA Developer AMI and F1 instances.

The new AMI (intended for F2 instances) runs on Ubuntu 20.04. I made the changes necessary for Connectal to compile successfully on Ubuntu 20.04. I also made sure that it compiles on Ubuntu 24.04 as well, since that's one of the most recent systems I expect most people will want to use.

If there are people with access to older machines who could try to compile (i.e. `sudo make install`) and report any additional fixes needed, say, for Ubuntu 16.04, that would be appreciated.

Unfortunately, I haven't quite figured out how to actually support synthesis for F2 instances yet.